### PR TITLE
Add find screen

### DIFF
--- a/persistence/PuzzleController.java
+++ b/persistence/PuzzleController.java
@@ -15,9 +15,11 @@ import pg13.models.Puzzle;
  *
  */
 public class PuzzleController {
+	static private PuzzleController pc_instance;
+	private ArrayList<Puzzle> puzzleList;
 
-	public ArrayList<Puzzle> getAllPuzzles() {
-		ArrayList<Puzzle> puzzleList = new ArrayList<Puzzle>();
+	public PuzzleController(){
+		this.puzzleList = new ArrayList<Puzzle>();
 		String[][] dummyPuzzles = {
 				{"Toughy", "Will", "Testing", "Easy"},
 				{"Wootbots", "Will", "Fake", "Average"}
@@ -27,7 +29,24 @@ public class PuzzleController {
 			Cryptogram dummyPuzzle = new Cryptogram(def[0], def[1], def[2], def[3], new Date(), "Fake!");
 			puzzleList.add(dummyPuzzle);
 		}
-		return puzzleList;
+
+	}
+
+	public static PuzzleController getInstance(){
+		if(pc_instance == null)
+		{
+			pc_instance = new PuzzleController();
+		}
+		return pc_instance;
+	}
+	public ArrayList<Puzzle> getAllPuzzles() {
+		System.out.println("All puzzles:" + this.puzzleList);
+		return this.puzzleList;
+	}
+
+	public void persist(Puzzle puzzle){
+		this.puzzleList.add(puzzle);
+		System.out.println(this.puzzleList);
 	}
 
 }

--- a/persistence/PuzzleController.java
+++ b/persistence/PuzzleController.java
@@ -1,0 +1,33 @@
+/**
+ * 
+ */
+package persistence;
+
+import java.util.ArrayList;
+import java.util.Date;
+
+import pg13.models.Cryptogram;
+import pg13.models.Puzzle;
+
+/**
+ * A simple fake DB to serve up puzzles and act like a persistence layer.
+ * @author williamhumphreys-cloutier
+ *
+ */
+public class PuzzleController {
+
+	public ArrayList<Puzzle> getAllPuzzles() {
+		ArrayList<Puzzle> puzzleList = new ArrayList<Puzzle>();
+		String[][] dummyPuzzles = {
+				{"Toughy", "Will", "Testing", "Easy"},
+				{"Wootbots", "Will", "Fake", "Average"}
+		};
+		for(String[] def: dummyPuzzles)
+		{
+			Cryptogram dummyPuzzle = new Cryptogram(def[0], def[1], def[2], def[3], new Date(), "Fake!");
+			puzzleList.add(dummyPuzzle);
+		}
+		return puzzleList;
+	}
+
+}

--- a/pg13/business/create/PuzzleCreator.java
+++ b/pg13/business/create/PuzzleCreator.java
@@ -1,0 +1,17 @@
+package pg13.business.create;
+
+import persistence.PuzzleController;
+import pg13.models.Puzzle;
+
+public class PuzzleCreator {
+
+	private PuzzleController db;
+
+	public PuzzleCreator(){
+		this.db = PuzzleController.getInstance();
+	}
+	
+	public void save(Puzzle puzzle){
+		this.db.persist(puzzle);
+	}
+}

--- a/pg13/business/search/PuzzleAuthorColumnProvider.java
+++ b/pg13/business/search/PuzzleAuthorColumnProvider.java
@@ -1,0 +1,18 @@
+package pg13.business.search;
+
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+
+import pg13.models.Puzzle;
+
+/**
+ * Reports the author of a puzzle as a string for displaying in a table column.
+ * @author williamhumphreys-cloutier
+ */
+public class PuzzleAuthorColumnProvider extends ColumnLabelProvider {
+	@Override
+	public String getText(Object obj){
+		Puzzle p = (Puzzle) obj;
+		String author = p.getAuthor();
+		return author != null && author.length() > 0 ? author : "Guest";
+	}
+}

--- a/pg13/business/search/PuzzleCategoryColumnProvider.java
+++ b/pg13/business/search/PuzzleCategoryColumnProvider.java
@@ -1,0 +1,18 @@
+package pg13.business.search;
+
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+
+import pg13.models.Puzzle;
+
+/**
+ * Reports the category as a string of a puzzle for displaying in a table column.
+ * @author williamhumphreys-cloutier
+ */
+public class PuzzleCategoryColumnProvider extends ColumnLabelProvider {
+	@Override
+	public String getText(Object obj){
+		Puzzle p = (Puzzle) obj;
+		String category = p.getCategory();
+		return category != null && category.length() > 0 ? category : "Uncategorized";
+	}
+}

--- a/pg13/business/search/PuzzleDifficultyColumnProvider.java
+++ b/pg13/business/search/PuzzleDifficultyColumnProvider.java
@@ -1,0 +1,20 @@
+package pg13.business.search;
+
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+
+import pg13.models.Puzzle;
+
+/**
+ * Reports the difficulty as a string of a puzzle for displaying in a table column.
+ * @author williamhumphreys-cloutier
+ */
+public class PuzzleDifficultyColumnProvider extends ColumnLabelProvider {
+
+	@Override
+	public String getText(Object obj){
+		Puzzle p = (Puzzle) obj;
+		String difficulty = p.getDifficulty();
+		return difficulty != null && difficulty.length() > 0 ? difficulty : "Unrated";
+	}
+
+}

--- a/pg13/business/search/PuzzleTableDriver.java
+++ b/pg13/business/search/PuzzleTableDriver.java
@@ -1,10 +1,16 @@
 
 package pg13.business.search;
 
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jface.viewers.ColumnLabelProvider;
+
+import persistence.PuzzleController;
+import pg13.models.Cryptogram;
+import pg13.models.Puzzle;
 
 
 /**
@@ -15,18 +21,29 @@ import org.eclipse.jface.viewers.ColumnLabelProvider;
 public class PuzzleTableDriver {
 	
 	private Map<String, ColumnLabelProvider> columnLabels;
-	
+	private ArrayList<Puzzle> puzzleList;
+	private PuzzleController db;
+
 	/**
 	 * Constructor -- creates a puzzle table driver instance.
 	 * @author williamhumphreys-cloutier
 	 * @date June 1 2013
 	 */
-	public PuzzleTableDriver(){
+	public PuzzleTableDriver(ArrayList<Puzzle> puzzleList){
+		//initialize the puzzle controller
+		this.db = new PuzzleController();
+
+		// initialize the label providers
 		this.columnLabels = new HashMap<String, ColumnLabelProvider>();
 		this.columnLabels.put("Title", new PuzzleTitleColumnProvider());
 		this.columnLabels.put("Author", new PuzzleAuthorColumnProvider());
 		this.columnLabels.put("Category", new PuzzleCategoryColumnProvider());
 		this.columnLabels.put("Difficulty", new PuzzleDifficultyColumnProvider());
+
+		// set the initial puzzle list
+		this.puzzleList = puzzleList;
+		ArrayList<Puzzle> dbResponse = this.db.getAllPuzzles();
+		this.puzzleList.addAll(dbResponse);
 	}
 
 	public ColumnLabelProvider getColumnLabelProvider(String columnTitle) {

--- a/pg13/business/search/PuzzleTableDriver.java
+++ b/pg13/business/search/PuzzleTableDriver.java
@@ -1,0 +1,35 @@
+
+package pg13.business.search;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+
+
+/**
+ * A logic layer for interactions between the puzzle table GUI
+ * and persistence layers. Defines how the puzzle table acts and its data.
+ * @author williamhumphreys-cloutier
+ */
+public class PuzzleTableDriver {
+	
+	private Map<String, ColumnLabelProvider> columnLabels;
+	
+	/**
+	 * Constructor -- creates a puzzle table driver instance.
+	 * @author williamhumphreys-cloutier
+	 * @date June 1 2013
+	 */
+	public PuzzleTableDriver(){
+		this.columnLabels = new HashMap<String, ColumnLabelProvider>();
+		this.columnLabels.put("Title", new PuzzleTitleColumnProvider());
+		this.columnLabels.put("Author", new PuzzleAuthorColumnProvider());
+		this.columnLabels.put("Category", new PuzzleCategoryColumnProvider());
+		this.columnLabels.put("Difficulty", new PuzzleDifficultyColumnProvider());
+	}
+
+	public ColumnLabelProvider getColumnLabelProvider(String columnTitle) {
+		return this.columnLabels.get(columnTitle);
+	}
+}

--- a/pg13/business/search/PuzzleTableDriver.java
+++ b/pg13/business/search/PuzzleTableDriver.java
@@ -31,7 +31,7 @@ public class PuzzleTableDriver {
 	 */
 	public PuzzleTableDriver(ArrayList<Puzzle> puzzleList){
 		//initialize the puzzle controller
-		this.db = new PuzzleController();
+		this.db = PuzzleController.getInstance();
 
 		// initialize the label providers
 		this.columnLabels = new HashMap<String, ColumnLabelProvider>();
@@ -48,5 +48,11 @@ public class PuzzleTableDriver {
 
 	public ColumnLabelProvider getColumnLabelProvider(String columnTitle) {
 		return this.columnLabels.get(columnTitle);
+	}
+
+	public void refresh() {
+		ArrayList<Puzzle> dbResponse = this.db.getAllPuzzles();
+		this.puzzleList.clear();
+		this.puzzleList.addAll(dbResponse);
 	}
 }

--- a/pg13/business/search/PuzzleTitleColumnProvider.java
+++ b/pg13/business/search/PuzzleTitleColumnProvider.java
@@ -1,0 +1,19 @@
+package pg13.business.search;
+
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+
+import pg13.models.Puzzle;
+
+/**
+ * Reports the title as a string of a puzzle for displaying in a table column.
+ * @author williamhumphreys-cloutier
+ */
+
+public class PuzzleTitleColumnProvider extends ColumnLabelProvider {
+	@Override
+	public String getText(Object obj){
+		Puzzle p = (Puzzle) obj;
+		String title = p.getTitle();
+		return title != null && title.length() > 0 ? title : "Untitled";
+	}
+}

--- a/pg13/models/Cryptogram.java
+++ b/pg13/models/Cryptogram.java
@@ -29,9 +29,9 @@ public class Cryptogram extends Puzzle
 		this.plaintext = "";
 	}
 	
-	public Cryptogram(String author, String title, Date dateCreated, String plaintext)
+	public Cryptogram(String author, String title, String category, String difficulty, Date dateCreated, String plaintext)
 	{
-		super(author, title, dateCreated);
+		super(author, title, category, difficulty, dateCreated);
 		this.solutionMapping = setMappingKeys(false);
 		generateMappingKeys();
 		this.userMapping = setMappingKeys(true);

--- a/pg13/models/IFindable.java
+++ b/pg13/models/IFindable.java
@@ -35,6 +35,30 @@ public interface IFindable {
 	public void setTitle(String value);
 	
 	/**
+	 * Get the category of this object
+	 * @return The category of the object
+	 */
+	public String getCategory();
+
+	/**
+	 * Set the category of the object
+	 * @param value The new category of the object
+	 */
+	public void setCategory(String value);
+
+	/**
+	 * Get the difficulty of this object
+	 * @return The difficulty of the object
+	 */
+	public String getDifficulty();
+
+	/**
+	 * Set the difficulty of the object
+	 * @param value The new difficulty of the object
+	 */
+	public void setDifficulty(String value);
+
+	/**
 	 * Get the creation date of the object
 	 * @return The creation date of the object
 	 */

--- a/pg13/models/Puzzle.java
+++ b/pg13/models/Puzzle.java
@@ -3,7 +3,7 @@ package pg13.models;
 import java.util.Date;
 
 public abstract class Puzzle implements IFindable, ICreateable, IPlayable{
-	private String title, author;
+	private String title, author, category, difficulty;
 	private Date dateCreated;
 	private boolean isCompleted;
 
@@ -12,6 +12,8 @@ public abstract class Puzzle implements IFindable, ICreateable, IPlayable{
 		this.author = null;
 		this.isCompleted = false;
 		this.title = null;
+		this.category = null;
+		this.difficulty = null;
 		this.dateCreated = null;
 	}
 	
@@ -46,6 +48,22 @@ public abstract class Puzzle implements IFindable, ICreateable, IPlayable{
 
 	public void setTitle(String value) {
 		this.title = value;
+	}
+
+	public String getCategory() {
+		return category;
+	}
+
+	public void setCategory(String category) {
+		this.category = category;
+	}
+
+	public String getDifficulty() {
+		return difficulty;
+	}
+
+	public void setDifficulty(String difficulty) {
+		this.difficulty = difficulty;
 	}
 
 	public Date getDateCreated() {

--- a/pg13/models/Puzzle.java
+++ b/pg13/models/Puzzle.java
@@ -3,7 +3,7 @@ package pg13.models;
 import java.util.Date;
 
 public abstract class Puzzle implements IFindable, ICreateable, IPlayable{
-	private String title, author, category, difficulty;
+	private String title, description, author, category, difficulty;
 	private Date dateCreated;
 	private boolean isCompleted;
 
@@ -50,6 +50,14 @@ public abstract class Puzzle implements IFindable, ICreateable, IPlayable{
 
 	public void setTitle(String value) {
 		this.title = value;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
 	}
 
 	public String getCategory() {

--- a/pg13/models/Puzzle.java
+++ b/pg13/models/Puzzle.java
@@ -17,13 +17,15 @@ public abstract class Puzzle implements IFindable, ICreateable, IPlayable{
 		this.dateCreated = null;
 	}
 	
-	protected Puzzle(String author, String title, Date dateCreated)
+	protected Puzzle(String author, String title, String category, String difficulty, Date dateCreated)
 	{
 		this();
 		this.author = author;
 		this.isCompleted = false;
 		this.title = title;
 		this.dateCreated = dateCreated;
+		this.difficulty = difficulty;
+		this.category = category;
 	}
 	
 	public boolean isCompleted() {

--- a/pg13/presentation/FindScreen.java
+++ b/pg13/presentation/FindScreen.java
@@ -15,12 +15,31 @@ import org.eclipse.swt.custom.TableTree;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.custom.ScrolledComposite;
+import org.eclipse.jface.viewers.ColumnLabelProvider;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.TableViewerColumn;
+import org.eclipse.jface.viewers.Viewer;
+
+import pg13.business.search.PuzzleTableDriver;
+import pg13.models.Puzzle;
 
 public class FindScreen extends Composite 
 {
+	private static class ContentProvider implements IStructuredContentProvider {
+		public Object[] getElements(Object inputElement) {
+			return new Object[0];
+		}
+		public void dispose() {
+		}
+		public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+		}
+	}
 	private Text txtTitle;
 	private Text txtAuthor;
 	private Table table;
+	private TableViewer tableViewer;
+	private PuzzleTableDriver tableDriver;
 
 	/**
 	 * Creates and populates the Find screen.
@@ -200,101 +219,6 @@ public class FindScreen extends Composite
 		btnExpert.setText("Expert");
 		btnExpert.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
 		
-		// table which displays all the puzzles to play
-		table = new Table(this, SWT.BORDER | SWT.FULL_SELECTION);
-		FormData fd_table = new FormData();
-		fd_table.bottom = new FormAttachment(100, -10);
-		fd_table.right = new FormAttachment(100, -10);
-		fd_table.top = new FormAttachment(0, 10);
-		fd_table.left = new FormAttachment(separator, 10);
-		table.setLayoutData(fd_table);
-		table.setHeaderVisible(true);
-		table.setLinesVisible(true);
-		
-		TableColumn tblclmnTitle = new TableColumn(table, SWT.NONE);
-		tblclmnTitle.setMoveable(true);
-		tblclmnTitle.setWidth(136);
-		tblclmnTitle.setText("Title");
-		
-		TableColumn tblclmnAuthor = new TableColumn(table, SWT.NONE);
-		tblclmnAuthor.setMoveable(true);
-		tblclmnAuthor.setWidth(100);
-		tblclmnAuthor.setText("Author");
-		
-		TableColumn tblclmnCategory = new TableColumn(table, SWT.NONE);
-		tblclmnCategory.setMoveable(true);
-		tblclmnCategory.setWidth(100);
-		tblclmnCategory.setText("Category");
-		
-		TableColumn tblclmnDifficulty = new TableColumn(table, SWT.NONE);
-		tblclmnDifficulty.setMoveable(true);
-		tblclmnDifficulty.setWidth(100);
-		tblclmnDifficulty.setText("Difficulty");
-		
-		// some test entries to play with
-		TableItem testItem1 = new TableItem(table, SWT.NONE);
-		testItem1.setText(new String[] {"This is nothing", "Eric", "Animals", "Easy"});
-		
-		TableItem testItem2 = new TableItem(table, SWT.NONE);
-		testItem2.setText(new String[] {"This also does nothing", "Eric", "Science", "Average"});
-		
-		TableItem testItem3 = new TableItem(table, SWT.NONE);
-		testItem3.setText(new String[] {"Is three enough?", "Eric", "Computers", "Easy"});
-		
-		TableItem testItem4 = new TableItem(table, SWT.NONE);
-		testItem4.setText(new String[] {"Maybe four", "Eric", "Biology", "Difficult"});
-		
-		TableItem testItem5 = new TableItem(table, SWT.NONE);
-		testItem5.setText(new String[] {"Yeah, definitely four", "Eric", "Space", "Expert"});
-		
-		TableItem testItem6 = new TableItem(table, SWT.NONE);
-		testItem6.setText(new String[] {"Wait a minute..", "Eric", "Computers", "Difficult"});
-		
-		TableItem testItem7 = new TableItem(table, SWT.NONE);
-		testItem7.setText(new String[] {"Oops", "Eric", "Animals", "Average"});
-		
-		TableItem testItem8 = new TableItem(table, SWT.NONE);
-		testItem8.setText(new String[] {"Stop adding so many", "William", "Space", "Easy"});
-		
-		TableItem testItem9 = new TableItem(table, SWT.NONE);
-		testItem9.setText(new String[] {"Wait...", "William", "Biology", "Average"});
-		
-		TableItem testItem10 = new TableItem(table, SWT.NONE);
-		testItem10.setText(new String[] {"I can use these to test filters!", "William", "Sports", "Difficult"});
-		
-		TableItem testItem11 = new TableItem(table, SWT.NONE);
-		testItem11.setText(new String[] {"And how long names look on this display!", "Eric", "Space", "Easy"});
-		
-		TableItem testItem12 = new TableItem(table, SWT.NONE);
-		testItem12.setText(new String[] {"Yeah whatever", "William", "Science", "Average"});
-		
-		TableItem testItem13 = new TableItem(table, SWT.NONE);
-		testItem13.setText(new String[] {"Don't make Will talk like that", "Lauren", "Computers", "Expert"});
-		
-		TableItem testItem14 = new TableItem(table, SWT.NONE);
-		testItem14.setText(new String[] {"Hey...", "Lauren", "Biology", "Expert"});
-		
-		TableItem testItem15 = new TableItem(table, SWT.NONE);
-		testItem15.setText(new String[] {"Stop it!", "Lauren", "Science", "Expert"});
-		
-		TableItem testItem16 = new TableItem(table, SWT.NONE);
-		testItem16.setText(new String[] {"hehehe...", "Eric", "Politics", "Difficult"});
-		
-		TableItem testItem17 = new TableItem(table, SWT.NONE);
-		testItem17.setText(new String[] {"I'm here, too", "Paymahn", "Politics", "Average"});
-		
-		TableItem testItem18 = new TableItem(table, SWT.NONE);
-		testItem18.setText(new String[] {"Build failing...", "Travis", "Computers", "Easy"});
-		
-		TableItem testItem19 = new TableItem(table, SWT.NONE);
-		testItem19.setText(new String[] {"Shut up, Travis", "Eric", "Science", "Difficult"});
-		
-		TableItem testItem20 = new TableItem(table, SWT.NONE);
-		testItem20.setText(new String[] {"He's my friend", "William", "Computers", "Easy"});
-		
-		TableItem testItem21 = new TableItem(table, SWT.NONE);
-		testItem21.setText(new String[] {"This should be enough to test vertical scrolling", "Eric", "Space", "Expert"});
-		
 		// play the selected puzzle!
 		Button btnPlaySelectedPuzzle = new Button(this, SWT.NONE);
 		FormData fd_btnPlaySelectedPuzzle = new FormData();
@@ -305,8 +229,43 @@ public class FindScreen extends Composite
 		btnPlaySelectedPuzzle.setLayoutData(fd_btnPlaySelectedPuzzle);
 		btnPlaySelectedPuzzle.setText("Play Selected Puzzle");
 		
-		
+		// add business layer table driver
+		this.tableDriver = new PuzzleTableDriver();
 
+		// create a table viewer to show puzzles
+		this.tableViewer = new TableViewer(this, SWT.BORDER | SWT.FULL_SELECTION);
+		table = tableViewer.getTable();
+		FormData fd_table = new FormData();
+		fd_table.bottom = new FormAttachment(100, -10);
+		fd_table.right = new FormAttachment(100, -10);
+		fd_table.top = new FormAttachment(separator, 10, SWT.TOP);
+		fd_table.left = new FormAttachment(separator, 6);
+		table.setLayoutData(fd_table);
+		table.setLinesVisible(true);
+		table.setHeaderVisible(true);
+		table.setBackground(SWTResourceManager.getColor(SWT.COLOR_LIST_BACKGROUND));
+		this.createColumns(this, this.tableViewer);
+	}
+
+	private void createColumns(final Composite parent, final TableViewer viewer) {
+		String[] titles = { "Title", "Author", "Category", "Difficulty" };
+		int[] bounds = { 100, 100, 100, 100 };
+
+		// create each column
+		for(int i = 0; i < titles.length; i++)
+		{
+			TableViewerColumn col = createTableViewerColumn(titles[i], bounds[i], i);
+			col.setLabelProvider(this.tableDriver.getColumnLabelProvider(titles[i]));
+		}
+	}
+
+	private TableViewerColumn createTableViewerColumn(String title, int width, final int colNumber) {
+	    final TableViewerColumn viewerColumn = new TableViewerColumn(this.tableViewer, SWT.NONE);
+	    final TableColumn column = viewerColumn.getColumn();
+	    column.setText(title);
+	    column.setWidth(width);
+	    column.setResizable(true);
+	    return viewerColumn;
 	}
 
 	@Override

--- a/pg13/presentation/FindScreen.java
+++ b/pg13/presentation/FindScreen.java
@@ -283,4 +283,9 @@ public class FindScreen extends Composite
 	protected void checkSubclass() {
 		// Disable the check that prevents subclassing of SWT components
 	}
+
+	public void onLoad() {
+		this.tableDriver.refresh();
+		this.tableViewer.setInput(this.puzzleResults);
+	}
 }

--- a/pg13/presentation/FindScreen.java
+++ b/pg13/presentation/FindScreen.java
@@ -1,5 +1,7 @@
 package pg13.presentation;
 
+import java.util.ArrayList;
+
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.layout.FormLayout;
 import org.eclipse.swt.widgets.Label;
@@ -27,8 +29,9 @@ import pg13.models.Puzzle;
 public class FindScreen extends Composite 
 {
 	private static class ContentProvider implements IStructuredContentProvider {
-		public Object[] getElements(Object inputElement) {
-			return new Object[0];
+		public Object[] getElements(Object newElements) {
+		      ArrayList<Puzzle> puzzles = (ArrayList<Puzzle>) newElements;
+		      return puzzles.toArray();
 		}
 		public void dispose() {
 		}
@@ -40,6 +43,7 @@ public class FindScreen extends Composite
 	private Table table;
 	private TableViewer tableViewer;
 	private PuzzleTableDriver tableDriver;
+	private ArrayList<Puzzle> puzzleResults;
 
 	/**
 	 * Creates and populates the Find screen.
@@ -229,9 +233,6 @@ public class FindScreen extends Composite
 		btnPlaySelectedPuzzle.setLayoutData(fd_btnPlaySelectedPuzzle);
 		btnPlaySelectedPuzzle.setText("Play Selected Puzzle");
 		
-		// add business layer table driver
-		this.tableDriver = new PuzzleTableDriver();
-
 		// create a table viewer to show puzzles
 		this.tableViewer = new TableViewer(this, SWT.BORDER | SWT.FULL_SELECTION);
 		table = tableViewer.getTable();
@@ -244,7 +245,17 @@ public class FindScreen extends Composite
 		table.setLinesVisible(true);
 		table.setHeaderVisible(true);
 		table.setBackground(SWTResourceManager.getColor(SWT.COLOR_LIST_BACKGROUND));
+
+		// add business layer table driver
+		this.puzzleResults = new ArrayList<Puzzle>();
+		this.tableDriver = new PuzzleTableDriver(this.puzzleResults);
+
+		// make the columns
 		this.createColumns(this, this.tableViewer);
+
+		// add a content provider
+		this.tableViewer.setContentProvider(new ContentProvider());
+		this.tableViewer.setInput(this.puzzleResults);
 	}
 
 	private void createColumns(final Composite parent, final TableViewer viewer) {

--- a/pg13/presentation/FindScreen.java
+++ b/pg13/presentation/FindScreen.java
@@ -1,0 +1,316 @@
+package pg13.presentation;
+
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.layout.FormLayout;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FormData;
+import org.eclipse.swt.layout.FormAttachment;
+import org.eclipse.wb.swt.SWTResourceManager;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.custom.TableTree;
+import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.TableItem;
+import org.eclipse.swt.custom.ScrolledComposite;
+
+public class FindScreen extends Composite 
+{
+	private Text txtTitle;
+	private Text txtAuthor;
+	private Table table;
+
+	/**
+	 * Creates and populates the Find screen.
+	 * @author Eric
+	 * @param parent
+	 * @param style
+	 * @date May 31 2013
+	 */
+	public FindScreen(Composite parent, int style) 
+	{
+		super(parent, style);
+		setLayout(new FormLayout());
+		
+		// separates the left information from the results table
+		Label separator = new Label(this, SWT.SEPARATOR | SWT.VERTICAL);
+		FormData fd_separator = new FormData();
+		fd_separator.bottom = new FormAttachment(100);
+		fd_separator.top = new FormAttachment(0);
+		fd_separator.left = new FormAttachment(0, 200);
+		separator.setLayoutData(fd_separator);
+		
+		// "Find Puzzles to Play"
+		Label lblFindAPuzzle = new Label(this, SWT.NONE);
+		lblFindAPuzzle.setFont(SWTResourceManager.getFont("Segoe UI", 16, SWT.NORMAL));
+		FormData fd_lblFindAPuzzle = new FormData();
+		fd_lblFindAPuzzle.top = new FormAttachment(0, 10);
+		fd_lblFindAPuzzle.left = new FormAttachment(0, 10);
+		lblFindAPuzzle.setLayoutData(fd_lblFindAPuzzle);
+		lblFindAPuzzle.setText("Find Puzzles:");
+		
+		// composite that contains the radio buttons to filter puzzle search
+		Composite cmpPuzzleFilter = new Composite(this, SWT.BORDER);
+		cmpPuzzleFilter.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		cmpPuzzleFilter.setLayout(new FormLayout());
+		FormData fd_cmpPuzzleFilter = new FormData();
+		fd_cmpPuzzleFilter.bottom = new FormAttachment(lblFindAPuzzle, 84, SWT.BOTTOM);
+		fd_cmpPuzzleFilter.top = new FormAttachment(lblFindAPuzzle, 6);
+		fd_cmpPuzzleFilter.right = new FormAttachment(separator, -10);
+		fd_cmpPuzzleFilter.left = new FormAttachment(0, 10);
+		cmpPuzzleFilter.setLayoutData(fd_cmpPuzzleFilter);
+		
+		Button btnAllPuzzles = new Button(cmpPuzzleFilter, SWT.RADIO);
+		btnAllPuzzles.setSelection(true);
+		FormData fd_btnAllPuzzles = new FormData();
+		fd_btnAllPuzzles.right = new FormAttachment(100, -6);
+		fd_btnAllPuzzles.top = new FormAttachment(0, 6);
+		fd_btnAllPuzzles.left = new FormAttachment(0, 6);
+		btnAllPuzzles.setLayoutData(fd_btnAllPuzzles);
+		btnAllPuzzles.setText("All Puzzles");
+		btnAllPuzzles.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		
+		Button btnFriendsPuzzles = new Button(cmpPuzzleFilter, SWT.RADIO);
+		FormData fd_btnFriendsPuzzles = new FormData();
+		fd_btnFriendsPuzzles.top = new FormAttachment(0, 28);
+		fd_btnFriendsPuzzles.right = new FormAttachment(100, -6);
+		fd_btnFriendsPuzzles.left = new FormAttachment(0, 6);
+		btnFriendsPuzzles.setLayoutData(fd_btnFriendsPuzzles);
+		btnFriendsPuzzles.setText("My Friends' Puzzles");
+		btnFriendsPuzzles.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		
+		Button btnMyPuzzles = new Button(cmpPuzzleFilter, SWT.RADIO);
+		FormData fd_btnMyPuzzles = new FormData();
+		fd_btnMyPuzzles.right = new FormAttachment(100, -6);
+		fd_btnMyPuzzles.top = new FormAttachment(0, 50);
+		fd_btnMyPuzzles.left = new FormAttachment(0, 6);
+		btnMyPuzzles.setLayoutData(fd_btnMyPuzzles);
+		btnMyPuzzles.setText("My Puzzles");
+		btnMyPuzzles.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		
+		// composite that contains additional search filters for the properties of the puzzle
+		Composite cmpPuzzleSearch = new Composite(this, SWT.BORDER);
+		cmpPuzzleSearch.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		cmpPuzzleSearch.setLayout(new FormLayout());
+		FormData fd_cmpPuzzleSearch = new FormData();
+		fd_cmpPuzzleSearch.bottom = new FormAttachment(100, -40);
+		fd_cmpPuzzleSearch.right = new FormAttachment(separator, -10);
+		fd_cmpPuzzleSearch.top = new FormAttachment(cmpPuzzleFilter, 8);
+		fd_cmpPuzzleSearch.left = new FormAttachment(0, 10);
+		cmpPuzzleSearch.setLayoutData(fd_cmpPuzzleSearch);
+		
+		// search by title
+		Label lblTitle = new Label(cmpPuzzleSearch, SWT.NONE);
+		lblTitle.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		FormData fd_lblTitle = new FormData();
+		fd_lblTitle.top = new FormAttachment(0, 6);
+		fd_lblTitle.left = new FormAttachment(0, 6);
+		lblTitle.setLayoutData(fd_lblTitle);
+		lblTitle.setText("Title:");
+		
+		txtTitle = new Text(cmpPuzzleSearch, SWT.BORDER);
+		FormData fd_txtTitle = new FormData();
+		fd_txtTitle.right = new FormAttachment(100, -6);
+		fd_txtTitle.top = new FormAttachment(lblTitle, 2);
+		fd_txtTitle.left = new FormAttachment(0, 6);
+		txtTitle.setLayoutData(fd_txtTitle);
+		
+		// search by author
+		Label lblAuthor = new Label(cmpPuzzleSearch, SWT.NONE);
+		lblAuthor.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		FormData fd_lblAuthor = new FormData();
+		fd_lblAuthor.top = new FormAttachment(txtTitle, 6);
+		fd_lblAuthor.left = new FormAttachment(0, 6);
+		lblAuthor.setLayoutData(fd_lblAuthor);
+		lblAuthor.setText("Author:");
+		
+		txtAuthor = new Text(cmpPuzzleSearch, SWT.BORDER);
+		FormData fd_txtAuthor = new FormData();
+		fd_txtAuthor.top = new FormAttachment(lblAuthor, 2);
+		fd_txtAuthor.right = new FormAttachment(100, -6);
+		fd_txtAuthor.left = new FormAttachment(0, 6);
+		txtAuthor.setLayoutData(fd_txtAuthor);
+		
+		// filter by category
+		Label lblCategory = new Label(cmpPuzzleSearch, SWT.NONE);
+		lblCategory.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		FormData fd_lblCategory = new FormData();
+		fd_lblCategory.top = new FormAttachment(txtAuthor, 6);
+		fd_lblCategory.left = new FormAttachment(0, 6);
+		lblCategory.setLayoutData(fd_lblCategory);
+		lblCategory.setText("Category:");
+		
+		Combo cmbCategory = new Combo(cmpPuzzleSearch, SWT.NONE);
+		cmbCategory.setItems(new String[] {"All Categories", "Animals", "Biology", "Computers", "Games", "General Trivia", "Geography", "History", "Miscellaneous", "Politics", "Science", "Space", "Sports"});
+		FormData fd_cmbCategory = new FormData();
+		fd_cmbCategory.top = new FormAttachment(lblCategory, 2);
+		fd_cmbCategory.right = new FormAttachment(100, -6);
+		fd_cmbCategory.left = new FormAttachment(0, 6);
+		cmbCategory.setLayoutData(fd_cmbCategory);
+		cmbCategory.select(0);
+		
+		// filter by difficulty
+		Label lblDifficulty = new Label(cmpPuzzleSearch, SWT.NONE);
+		lblDifficulty.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		FormData fd_lblDifficulty = new FormData();
+		fd_lblDifficulty.top = new FormAttachment(cmbCategory, 8);
+		fd_lblDifficulty.left = new FormAttachment(0, 6);
+		lblDifficulty.setLayoutData(fd_lblDifficulty);
+		lblDifficulty.setText("Difficulty:");
+		
+		Button btnAllDifficulties = new Button(cmpPuzzleSearch, SWT.CHECK);
+		FormData fd_btnAllDifficulties = new FormData();
+		fd_btnAllDifficulties.top = new FormAttachment(lblDifficulty, 4);
+		fd_btnAllDifficulties.left = new FormAttachment(0, 6);
+		btnAllDifficulties.setLayoutData(fd_btnAllDifficulties);
+		btnAllDifficulties.setText("All Difficulties");
+		btnAllDifficulties.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		
+		Button btnEasy = new Button(cmpPuzzleSearch, SWT.CHECK);
+		FormData fd_btnEasy = new FormData();
+		fd_btnEasy.top = new FormAttachment(btnAllDifficulties, 4);
+		fd_btnEasy.left = new FormAttachment(0, 6);
+		btnEasy.setLayoutData(fd_btnEasy);
+		btnEasy.setText("Easy");
+		btnEasy.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		
+		Button btnAverage = new Button(cmpPuzzleSearch, SWT.CHECK);
+		FormData fd_btnAverage = new FormData();
+		fd_btnAverage.left = new FormAttachment(0, 6);
+		fd_btnAverage.top = new FormAttachment(btnEasy, 4);
+		btnAverage.setLayoutData(fd_btnAverage);
+		btnAverage.setText("Average");
+		btnAverage.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		
+		Button btnDifficult = new Button(cmpPuzzleSearch, SWT.CHECK);
+		FormData fd_btnDifficult = new FormData();
+		fd_btnDifficult.top = new FormAttachment(btnAverage, 4);
+		fd_btnDifficult.left = new FormAttachment(0, 6);
+		btnDifficult.setLayoutData(fd_btnDifficult);
+		btnDifficult.setText("Difficult");
+		btnDifficult.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		
+		Button btnExpert = new Button(cmpPuzzleSearch, SWT.CHECK);
+		FormData fd_btnExpert = new FormData();
+		fd_btnExpert.top = new FormAttachment(btnDifficult, 4);
+		fd_btnExpert.left = new FormAttachment(0, 6);
+		btnExpert.setLayoutData(fd_btnExpert);
+		btnExpert.setText("Expert");
+		btnExpert.setBackground(SWTResourceManager.getColor(SWT.COLOR_WHITE));
+		
+		// table which displays all the puzzles to play
+		table = new Table(this, SWT.BORDER | SWT.FULL_SELECTION);
+		FormData fd_table = new FormData();
+		fd_table.bottom = new FormAttachment(100, -10);
+		fd_table.right = new FormAttachment(100, -10);
+		fd_table.top = new FormAttachment(0, 10);
+		fd_table.left = new FormAttachment(separator, 10);
+		table.setLayoutData(fd_table);
+		table.setHeaderVisible(true);
+		table.setLinesVisible(true);
+		
+		TableColumn tblclmnTitle = new TableColumn(table, SWT.NONE);
+		tblclmnTitle.setMoveable(true);
+		tblclmnTitle.setWidth(136);
+		tblclmnTitle.setText("Title");
+		
+		TableColumn tblclmnAuthor = new TableColumn(table, SWT.NONE);
+		tblclmnAuthor.setMoveable(true);
+		tblclmnAuthor.setWidth(100);
+		tblclmnAuthor.setText("Author");
+		
+		TableColumn tblclmnCategory = new TableColumn(table, SWT.NONE);
+		tblclmnCategory.setMoveable(true);
+		tblclmnCategory.setWidth(100);
+		tblclmnCategory.setText("Category");
+		
+		TableColumn tblclmnDifficulty = new TableColumn(table, SWT.NONE);
+		tblclmnDifficulty.setMoveable(true);
+		tblclmnDifficulty.setWidth(100);
+		tblclmnDifficulty.setText("Difficulty");
+		
+		// some test entries to play with
+		TableItem testItem1 = new TableItem(table, SWT.NONE);
+		testItem1.setText(new String[] {"This is nothing", "Eric", "Animals", "Easy"});
+		
+		TableItem testItem2 = new TableItem(table, SWT.NONE);
+		testItem2.setText(new String[] {"This also does nothing", "Eric", "Science", "Average"});
+		
+		TableItem testItem3 = new TableItem(table, SWT.NONE);
+		testItem3.setText(new String[] {"Is three enough?", "Eric", "Computers", "Easy"});
+		
+		TableItem testItem4 = new TableItem(table, SWT.NONE);
+		testItem4.setText(new String[] {"Maybe four", "Eric", "Biology", "Difficult"});
+		
+		TableItem testItem5 = new TableItem(table, SWT.NONE);
+		testItem5.setText(new String[] {"Yeah, definitely four", "Eric", "Space", "Expert"});
+		
+		TableItem testItem6 = new TableItem(table, SWT.NONE);
+		testItem6.setText(new String[] {"Wait a minute..", "Eric", "Computers", "Difficult"});
+		
+		TableItem testItem7 = new TableItem(table, SWT.NONE);
+		testItem7.setText(new String[] {"Oops", "Eric", "Animals", "Average"});
+		
+		TableItem testItem8 = new TableItem(table, SWT.NONE);
+		testItem8.setText(new String[] {"Stop adding so many", "William", "Space", "Easy"});
+		
+		TableItem testItem9 = new TableItem(table, SWT.NONE);
+		testItem9.setText(new String[] {"Wait...", "William", "Biology", "Average"});
+		
+		TableItem testItem10 = new TableItem(table, SWT.NONE);
+		testItem10.setText(new String[] {"I can use these to test filters!", "William", "Sports", "Difficult"});
+		
+		TableItem testItem11 = new TableItem(table, SWT.NONE);
+		testItem11.setText(new String[] {"And how long names look on this display!", "Eric", "Space", "Easy"});
+		
+		TableItem testItem12 = new TableItem(table, SWT.NONE);
+		testItem12.setText(new String[] {"Yeah whatever", "William", "Science", "Average"});
+		
+		TableItem testItem13 = new TableItem(table, SWT.NONE);
+		testItem13.setText(new String[] {"Don't make Will talk like that", "Lauren", "Computers", "Expert"});
+		
+		TableItem testItem14 = new TableItem(table, SWT.NONE);
+		testItem14.setText(new String[] {"Hey...", "Lauren", "Biology", "Expert"});
+		
+		TableItem testItem15 = new TableItem(table, SWT.NONE);
+		testItem15.setText(new String[] {"Stop it!", "Lauren", "Science", "Expert"});
+		
+		TableItem testItem16 = new TableItem(table, SWT.NONE);
+		testItem16.setText(new String[] {"hehehe...", "Eric", "Politics", "Difficult"});
+		
+		TableItem testItem17 = new TableItem(table, SWT.NONE);
+		testItem17.setText(new String[] {"I'm here, too", "Paymahn", "Politics", "Average"});
+		
+		TableItem testItem18 = new TableItem(table, SWT.NONE);
+		testItem18.setText(new String[] {"Build failing...", "Travis", "Computers", "Easy"});
+		
+		TableItem testItem19 = new TableItem(table, SWT.NONE);
+		testItem19.setText(new String[] {"Shut up, Travis", "Eric", "Science", "Difficult"});
+		
+		TableItem testItem20 = new TableItem(table, SWT.NONE);
+		testItem20.setText(new String[] {"He's my friend", "William", "Computers", "Easy"});
+		
+		TableItem testItem21 = new TableItem(table, SWT.NONE);
+		testItem21.setText(new String[] {"This should be enough to test vertical scrolling", "Eric", "Space", "Expert"});
+		
+		// play the selected puzzle!
+		Button btnPlaySelectedPuzzle = new Button(this, SWT.NONE);
+		FormData fd_btnPlaySelectedPuzzle = new FormData();
+		fd_btnPlaySelectedPuzzle.right = new FormAttachment(separator, -10);
+		fd_btnPlaySelectedPuzzle.bottom = new FormAttachment(100, -10);
+		fd_btnPlaySelectedPuzzle.top = new FormAttachment(100, -36);
+		fd_btnPlaySelectedPuzzle.left = new FormAttachment(lblFindAPuzzle, 0, SWT.LEFT);
+		btnPlaySelectedPuzzle.setLayoutData(fd_btnPlaySelectedPuzzle);
+		btnPlaySelectedPuzzle.setText("Play Selected Puzzle");
+		
+		
+
+	}
+
+	@Override
+	protected void checkSubclass() {
+		// Disable the check that prevents subclassing of SWT components
+	}
+}

--- a/pg13/presentation/MainWindow.java
+++ b/pg13/presentation/MainWindow.java
@@ -86,6 +86,7 @@ public class MainWindow
 			{
 				// show the find screen and hide other screens
 				cmpCreateScreen.setVisible(false);
+				cmpFindScreen.onLoad();
 				cmpFindScreen.setVisible(true);
 			}
 		});

--- a/pg13/presentation/MainWindow.java
+++ b/pg13/presentation/MainWindow.java
@@ -31,6 +31,7 @@ public class MainWindow
 	private Display display;
 	private Shell shell;
 	private CreateScreen cmpCreateScreen;
+	private FindScreen cmpFindScreen;
 	private Label lblLoggedInAs;
 
 	/**
@@ -77,8 +78,17 @@ public class MainWindow
 		shell.setLayout(new FormLayout());
 		
 		// play button
-		// TODO make this button do something
 		Button btnPlay = new Button(shell, SWT.NONE);
+		btnPlay.addSelectionListener(new SelectionAdapter() 
+		{
+			@Override
+			public void widgetSelected(SelectionEvent e) 
+			{
+				// show the find screen and hide other screens
+				cmpCreateScreen.setVisible(false);
+				cmpFindScreen.setVisible(true);
+			}
+		});
 		FormData fd_btnPlay = new FormData();
 		fd_btnPlay.right = new FormAttachment(0, 86);
 		fd_btnPlay.top = new FormAttachment(0, 11);
@@ -103,8 +113,9 @@ public class MainWindow
 			@Override
 			public void widgetSelected(SelectionEvent e) 
 			{
-				// show the create screen
+				// show the create screen and hide other screens
 				cmpCreateScreen.setVisible(true);
+				cmpFindScreen.setVisible(false);
 			}
 		});
 		FormData fd_btnCreate = new FormData();
@@ -189,7 +200,17 @@ public class MainWindow
 		cmpCreateScreen.setLayoutData(fd_cmpCreateScreen);
 		cmpCreateScreen.setVisible(false);
 		
-		// TODO load a play screen here as well, as with the create screen
+		// load the create screen, but hide it
+		cmpFindScreen = new FindScreen(cmpMainArea, SWT.NONE);
+		FormData fd_cmpFindScreen = new FormData();
+		fd_cmpFindScreen.bottom = new FormAttachment(100);
+		fd_cmpFindScreen.right = new FormAttachment(100);
+		fd_cmpFindScreen.top = new FormAttachment(0);
+		fd_cmpFindScreen.left = new FormAttachment(0);
+		cmpFindScreen.setLayoutData(fd_cmpFindScreen);
+		cmpFindScreen.setVisible(false);
+		
+		// TODO load and hide a play screen here as well
 		
 		// show the window
 		shell.open();

--- a/pg13/presentation/PuzzlePropertiesWidget.java
+++ b/pg13/presentation/PuzzlePropertiesWidget.java
@@ -3,6 +3,10 @@ package pg13.presentation;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.wb.swt.SWTResourceManager;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.FormLayout;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.layout.FormData;
@@ -10,7 +14,10 @@ import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Button;
+
+import pg13.business.create.PuzzleCreator;
 import pg13.models.Cryptogram;
+import pg13.models.Puzzle;
 
 public class PuzzlePropertiesWidget extends Composite 
 {
@@ -21,6 +28,7 @@ public class PuzzlePropertiesWidget extends Composite
 	private Label lblCategory;
 	private Label lblDifficulty;
 	private Combo cmbDificulty;
+	private Combo cmbCategory;
 	
 	/**
 	 * Creates and populates the properties widget.
@@ -29,11 +37,12 @@ public class PuzzlePropertiesWidget extends Composite
 	 * @param style
 	 * @date May 29 2013
 	 */
-	public PuzzlePropertiesWidget(Composite parent, int style, Cryptogram displayingPuzzle, boolean editMode) 
+	public PuzzlePropertiesWidget(Composite parent, int style, Cryptogram displayingPuzzle, boolean editMode)
 	{
 		super(parent, style);
 		this.editMode = editMode;
 		this.displayingPuzzle = displayingPuzzle;
+		final Puzzle puzzle = displayingPuzzle;
 		setLayout(new FormLayout());
 		
 		// puzzle name
@@ -46,6 +55,12 @@ public class PuzzlePropertiesWidget extends Composite
 		fd_txtPuzzleName.bottom = new FormAttachment(0, 49);
 		fd_txtPuzzleName.right = new FormAttachment(100, -10);
 		txtPuzzleName.setLayoutData(fd_txtPuzzleName);
+		txtPuzzleName.addModifyListener(new ModifyListener(){
+			@Override
+			public void modifyText(ModifyEvent e) {
+				puzzle.setTitle(txtPuzzleName.getText());
+			}
+		});
 		
 		// puzzle description label
 		Label lblDescription = new Label(this, SWT.NONE);
@@ -54,6 +69,7 @@ public class PuzzlePropertiesWidget extends Composite
 		fd_lblDescription.left = new FormAttachment(0, 10);
 		lblDescription.setLayoutData(fd_lblDescription);
 		lblDescription.setText("Description");
+
 		
 		// puzzle description text field
 		txtDescription = new Text(this, SWT.BORDER | SWT.WRAP);
@@ -64,7 +80,13 @@ public class PuzzlePropertiesWidget extends Composite
 		fd_txtDescription.top = new FormAttachment(lblDescription, 4);
 		fd_txtDescription.left = new FormAttachment(0, 10);
 		txtDescription.setLayoutData(fd_txtDescription);
-		
+		txtDescription.addModifyListener(new ModifyListener(){
+			@Override
+			public void modifyText(ModifyEvent e) {
+				puzzle.setDescription(txtDescription.getText());
+			}
+		});
+
 		// category label
 		lblCategory = new Label(this, SWT.NONE);
 		FormData fd_lblCategory = new FormData();
@@ -74,7 +96,7 @@ public class PuzzlePropertiesWidget extends Composite
 		lblCategory.setText("Category");
 		
 		// category selection box
-		Combo cmbCategory = new Combo(this, SWT.NONE);
+		cmbCategory = new Combo(this, SWT.NONE);
 		cmbCategory.setItems(new String[] {"Animals", "Biology", "Computers", "Games", "General Trivia", "Geography", "History", "Miscellaneous", "Politics", "Science", "Space", "Sports"});
 		FormData fd_cmbCategory = new FormData();
 		fd_cmbCategory.right = new FormAttachment(60);
@@ -82,7 +104,14 @@ public class PuzzlePropertiesWidget extends Composite
 		fd_cmbCategory.left = new FormAttachment(0, 10);
 		cmbCategory.setLayoutData(fd_cmbCategory);
 		cmbCategory.select(7);
-		
+		cmbCategory.addModifyListener(new ModifyListener(){
+			@Override
+			public void modifyText(ModifyEvent e) {
+				puzzle.setCategory(cmbCategory.getText());
+			}
+		});
+
+
 		// difficulty label
 		lblDifficulty = new Label(this, SWT.NONE);
 		FormData fd_lblDifficulty = new FormData();
@@ -100,6 +129,13 @@ public class PuzzlePropertiesWidget extends Composite
 		fd_cmbDificulty.left = new FormAttachment(0, 10);
 		cmbDificulty.setLayoutData(fd_cmbDificulty);
 		cmbDificulty.select(1);
+		cmbDificulty.addModifyListener(new ModifyListener(){
+			@Override
+			public void modifyText(ModifyEvent e) {
+				puzzle.setDifficulty(cmbDificulty.getText());
+			}
+		});
+
 		
 		// save puzzle button
 		Button btnSavePuzzle = new Button(this, SWT.NONE);
@@ -110,7 +146,19 @@ public class PuzzlePropertiesWidget extends Composite
 		fd_btnSavePuzzle.right = new FormAttachment(50, 70);
 		btnSavePuzzle.setLayoutData(fd_btnSavePuzzle);
 		btnSavePuzzle.setText("Save this Puzzle");
+		btnSavePuzzle.addSelectionListener(new SelectionListener(){
 
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				new PuzzleCreator().save(puzzle);
+			}
+
+			@Override
+			public void widgetDefaultSelected(SelectionEvent e) {
+				new PuzzleCreator().save(puzzle);
+			}
+
+		});
 	}
 
 	@Override

--- a/tests/business/search/PuzzleAuthorColumnProviderTest.java
+++ b/tests/business/search/PuzzleAuthorColumnProviderTest.java
@@ -1,0 +1,41 @@
+package tests.business.search;
+
+import pg13.business.search.PuzzleAuthorColumnProvider;
+import pg13.models.Cryptogram;
+import junit.framework.TestCase;
+
+/**
+ * Tests for PuzzleAuthorColumnProvider
+ * @author williamhumphreys-cloutier
+ *
+ */
+public class PuzzleAuthorColumnProviderTest extends TestCase {
+
+	private Cryptogram testCryptogram;
+	private PuzzleAuthorColumnProvider authorProvider;
+	
+	protected void setUp(){
+		this.testCryptogram = new Cryptogram();
+		this.authorProvider = new PuzzleAuthorColumnProvider();
+	}
+	
+	public void testEmptyAuthor(){
+		this.testCryptogram.setAuthor("");
+		String resultAuthor = this.authorProvider.getText(this.testCryptogram);
+		assertEquals(resultAuthor, "Guest");
+	}
+
+	public void testNullAuthor(){
+		this.testCryptogram.setAuthor(null);
+		String resultAuthor = this.authorProvider.getText(this.testCryptogram);
+		assertEquals(resultAuthor, "Guest");		
+	}
+	
+	public void testNormalAuthor(){
+		String originalAuthor = "Will Coolcat";
+		this.testCryptogram.setAuthor(originalAuthor);
+		String resultAuthor = this.authorProvider.getText(this.testCryptogram);
+		assertEquals(resultAuthor, originalAuthor);
+	}
+
+}

--- a/tests/business/search/PuzzleCategoryColumnProviderTest.java
+++ b/tests/business/search/PuzzleCategoryColumnProviderTest.java
@@ -1,0 +1,41 @@
+package tests.business.search;
+
+import pg13.business.search.PuzzleCategoryColumnProvider;
+import pg13.models.Cryptogram;
+import junit.framework.TestCase;
+
+/**
+ * Tests for PuzzleCategoryColumnProvider
+ * @category williamhumphreys-cloutier
+ *
+ */
+public class PuzzleCategoryColumnProviderTest extends TestCase {
+
+	private Cryptogram testCryptogram;
+	private PuzzleCategoryColumnProvider categoryProvider;
+	
+	protected void setUp(){
+		this.testCryptogram = new Cryptogram();
+		this.categoryProvider = new PuzzleCategoryColumnProvider();
+	}
+	
+	public void testEmptyCategory(){
+		this.testCryptogram.setCategory("");
+		String resultCategory = this.categoryProvider.getText(this.testCryptogram);
+		assertEquals(resultCategory, "Uncategorized");
+	}
+
+	public void testNullCategory(){
+		this.testCryptogram.setCategory(null);
+		String resultCategory = this.categoryProvider.getText(this.testCryptogram);
+		assertEquals(resultCategory, "Uncategorized");
+	}
+	
+	public void testNormalCategory(){
+		String originalCategory = "Will Coolcat";
+		this.testCryptogram.setCategory(originalCategory);
+		String resultCategory = this.categoryProvider.getText(this.testCryptogram);
+		assertEquals(resultCategory, originalCategory);
+	}
+
+}

--- a/tests/business/search/PuzzleDifficultyColumnProviderTest.java
+++ b/tests/business/search/PuzzleDifficultyColumnProviderTest.java
@@ -1,0 +1,40 @@
+package tests.business.search;
+
+import pg13.business.search.PuzzleDifficultyColumnProvider;
+import pg13.models.Cryptogram;
+import junit.framework.TestCase;
+
+/**
+ * 
+ * Tests for PuzzleDifficultyColumnProvider
+ * @author williamhumphreys-cloutier
+ *
+ */
+public class PuzzleDifficultyColumnProviderTest extends TestCase {
+	private Cryptogram testCryptogram;
+	private PuzzleDifficultyColumnProvider difficultyProvider;
+	
+	protected void setUp(){
+		this.testCryptogram = new Cryptogram();
+		this.difficultyProvider = new PuzzleDifficultyColumnProvider();
+	}
+	
+	public void testEmptyDifficulty(){
+		this.testCryptogram.setDifficulty("");
+		String resultDifficulty = this.difficultyProvider.getText(this.testCryptogram);
+		assertEquals(resultDifficulty, "Unrated");
+	}
+
+	public void testNullDifficulty(){
+		this.testCryptogram.setDifficulty(null);
+		String resultDifficulty = this.difficultyProvider.getText(this.testCryptogram);
+		assertEquals(resultDifficulty, "Unrated");
+	}
+	
+	public void testNormalDifficulty(){
+		String originalDifficulty = "Puzzle of Doom!";
+		this.testCryptogram.setDifficulty(originalDifficulty);
+		String resultDifficulty = this.difficultyProvider.getText(this.testCryptogram);
+		assertEquals(resultDifficulty, originalDifficulty);
+	}
+}

--- a/tests/business/search/PuzzleTitleColumnProviderTest.java
+++ b/tests/business/search/PuzzleTitleColumnProviderTest.java
@@ -1,0 +1,40 @@
+package tests.business.search;
+
+import pg13.business.search.PuzzleTitleColumnProvider;
+import pg13.models.Cryptogram;
+import junit.framework.TestCase;
+
+/**
+ * Tests for PuzzleTitleColumnProvider
+ * @author williamhumphreys-cloutier
+ */
+public class PuzzleTitleColumnProviderTest extends TestCase {
+
+	private Cryptogram testCryptogram;
+	private PuzzleTitleColumnProvider titleProvider;
+	
+	protected void setUp(){
+		this.testCryptogram = new Cryptogram();
+		this.titleProvider = new PuzzleTitleColumnProvider();
+	}
+	
+	public void testEmptyTitle(){
+		this.testCryptogram.setTitle("");
+		String resultTitle = this.titleProvider.getText(this.testCryptogram);
+		assertEquals(resultTitle, "Untitled");
+	}
+
+	public void testNullTitle(){
+		this.testCryptogram.setTitle(null);
+		String resultTitle = this.titleProvider.getText(this.testCryptogram);
+		assertEquals(resultTitle, "Untitled");		
+	}
+	
+	public void testNormalTitle(){
+		String originalTitle = "Puzzle of Doom!";
+		this.testCryptogram.setTitle(originalTitle);
+		String resultTitle = this.titleProvider.getText(this.testCryptogram);
+		assertEquals(resultTitle, originalTitle);
+	}
+
+}

--- a/tests/models/CryptogramTest.java
+++ b/tests/models/CryptogramTest.java
@@ -11,6 +11,8 @@ import pg13.models.Cryptogram;
 	{
 		private final String DEFAULT_TITLE = "Practice Cryptogram";
 		private final String DEFAULT_AUTHOR = "Lauren Slusky";
+		private final String DEFAULT_CATEGORY = "Hamsters";
+		private final String DEFAULT_DIFFICULTY = "Easy";
 		private final Date DEFAULT_DATE = new Date();
 		private final String DEFAULT_PLAINTEXT = "This is a test.";
 		
@@ -29,7 +31,7 @@ import pg13.models.Cryptogram;
 		
 		public void testCryptogramGeneralData()
 		{
-			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_DATE, DEFAULT_PLAINTEXT);
+			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_CATEGORY, DEFAULT_DIFFICULTY, DEFAULT_DATE, DEFAULT_PLAINTEXT);
 			assertNotNull(cryptogram);
 			assertEquals(DEFAULT_AUTHOR, cryptogram.getAuthor());
 			assertEquals(DEFAULT_TITLE, cryptogram.getTitle());
@@ -39,7 +41,7 @@ import pg13.models.Cryptogram;
 
 		public void testCryptogramEmptyAuthor()
 		{
-			cryptogram = new Cryptogram("", DEFAULT_TITLE, DEFAULT_DATE, "");
+			cryptogram = new Cryptogram("", DEFAULT_TITLE, DEFAULT_CATEGORY, DEFAULT_DIFFICULTY, DEFAULT_DATE, "");
 			assertEquals("", cryptogram.getAuthor());
 			assertEquals(DEFAULT_TITLE, cryptogram.getTitle());
 			assertEquals(DEFAULT_DATE, cryptogram.getDateCreated());
@@ -48,7 +50,7 @@ import pg13.models.Cryptogram;
 		
 		public void testCryptogramEmptyTitle()
 		{
-			cryptogram = new Cryptogram(DEFAULT_AUTHOR, "", DEFAULT_DATE, "");
+			cryptogram = new Cryptogram(DEFAULT_AUTHOR, "", DEFAULT_CATEGORY, DEFAULT_DIFFICULTY, DEFAULT_DATE, "");
 			assertEquals("", cryptogram.getTitle());		
 			assertEquals(DEFAULT_AUTHOR, cryptogram.getAuthor());
 			assertEquals(DEFAULT_DATE, cryptogram.getDateCreated());
@@ -57,7 +59,7 @@ import pg13.models.Cryptogram;
 		
 		public void testCryptogramEmptyDate()
 		{
-			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, null, "");
+			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_CATEGORY, DEFAULT_DIFFICULTY, null, "");
 			assertEquals(null, cryptogram.getDateCreated());
 			assertEquals(DEFAULT_AUTHOR, cryptogram.getAuthor());
 			assertEquals(DEFAULT_TITLE, cryptogram.getTitle());
@@ -66,7 +68,7 @@ import pg13.models.Cryptogram;
 		
 		public void testCipherTextWorksNoPunctuation()
 		{
-			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_DATE, DEFAULT_PLAINTEXT);
+			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_CATEGORY, DEFAULT_DIFFICULTY, DEFAULT_DATE, DEFAULT_PLAINTEXT);
 			assertEquals(DEFAULT_PLAINTEXT, cryptogram.getPlaintext());
 			assertNotSame(DEFAULT_PLAINTEXT, cryptogram.getCiphertext());
 			assertFalse(DEFAULT_PLAINTEXT.equals(cryptogram.getCiphertext())); //for some reason there isn't assertNotEquals in JUnit
@@ -76,7 +78,7 @@ import pg13.models.Cryptogram;
 		public void testCipherTextWorksPunctuation()
 		{
 			String plaintext =  "This. is, a! test%";
-			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_DATE, plaintext);
+			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_CATEGORY, DEFAULT_DIFFICULTY, DEFAULT_DATE, plaintext);
 			assertEquals(plaintext, cryptogram.getPlaintext());
 			assertNotSame(plaintext, cryptogram.getCiphertext());
 			assertTrue((cryptogram.decrypt(cryptogram.getSolutionMapping())).equalsIgnoreCase(plaintext));
@@ -87,7 +89,7 @@ import pg13.models.Cryptogram;
 		
 		public void testCryptogramEmptyPlainText()
 		{
-			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_DATE, "");
+			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_CATEGORY, DEFAULT_DIFFICULTY, DEFAULT_DATE, "");
 			assertEquals("", cryptogram.getPlaintext());
 			assertEquals("", cryptogram.getCiphertext());
 			assertEquals("", cryptogram.decrypt(cryptogram.getSolutionMapping()));
@@ -99,7 +101,7 @@ import pg13.models.Cryptogram;
 		public void testCryptogramAllPuncatuationPlainText()
 		{	
 			String plaintext = "!!!!!!!!!!!!!!!!!!!!!&!!!!!!!!!!";
-			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_DATE, plaintext);
+			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_CATEGORY, DEFAULT_DIFFICULTY, DEFAULT_DATE, plaintext);
 			assertEquals(plaintext, cryptogram.getPlaintext());
 			assertEquals(plaintext, cryptogram.getCiphertext());
 			assertEquals(plaintext, cryptogram.decrypt(cryptogram.getSolutionMapping()));
@@ -107,7 +109,7 @@ import pg13.models.Cryptogram;
 		
 		public void testCryptogramCryptogramCompletion()
 		{
-			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_DATE, "This is a test.");
+			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_CATEGORY, DEFAULT_DIFFICULTY, DEFAULT_DATE, "This is a test.");
 			setUserMappingForTest(cryptogram);
 			assertTrue(cryptogram.isCompleted());
 		}
@@ -123,7 +125,7 @@ import pg13.models.Cryptogram;
 
 		public void testCryptogramUserUses()
 		{
-			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_DATE, "This is a test.");
+			cryptogram = new Cryptogram(DEFAULT_AUTHOR, DEFAULT_TITLE, DEFAULT_CATEGORY, DEFAULT_DIFFICULTY, DEFAULT_DATE, "This is a test.");
 			cryptogram.setUserPlaintextForCiphertext('h', 'X');
 			assertEquals(cryptogram.getUserPlaintextFromCiphertext('X'), 'H');
 			assertNotNull(cryptogram.getUserMapping());


### PR DESCRIPTION
Makes a functional find screen that lists all puzzles and adds in basic persistence/business layers. Creating a puzzle now persists it in memory and it is visible on the find screen.
