### PR TITLE
Random Number Generator Stub for Cryptogram Tests

### DIFF
--- a/src/pg13/models/Cryptogram.java
+++ b/src/pg13/models/Cryptogram.java
@@ -14,9 +14,13 @@ public class Cryptogram extends Puzzle
 											// when solving a cryptogram ordered
 											// by ciphertext
 
+	private IRandomNumberGenerator randomNumberGenerator;
+	
 	public Cryptogram()
 	{
 		super();
+		this.randomNumberGenerator = new RealRandomNumberGenerator();
+		
 		this.solutionMapping = setMappingKeys(false);
 		generateMappingKeys();
 		this.userMapping = setMappingKeys(true);
@@ -25,22 +29,37 @@ public class Cryptogram extends Puzzle
 	}
 
 	public Cryptogram(User user, String title, String description,
-			Category category, Difficulty difficulty, String plaintext)
+			Category category, Difficulty difficulty, String plaintext, IRandomNumberGenerator generator)
 	{
 		super(user, title, description, category, difficulty);
+		this.randomNumberGenerator = generator;
+		
 		this.solutionMapping = setMappingKeys(false);
 		generateMappingKeys();
 		this.userMapping = setMappingKeys(true);
 		this.plaintext = plaintext;
 		this.ciphertext = encrypt();
 	}
+	
+	public Cryptogram(User user, String title, String description,
+			Category category, Difficulty difficulty, String plaintext)
+	{
+		this(user, title, description, category, difficulty, plaintext, new RealRandomNumberGenerator());
+	}
 
+	public Cryptogram(User user, String title, String description,
+			Category category, Difficulty difficulty, String plaintext, long id, IRandomNumberGenerator generator)
+	{
+		this(user, title, description, category, difficulty, plaintext, generator);
+		this.setID(id);
+	}
+	
 	public Cryptogram(User user, String title, String description,
 			Category category, Difficulty difficulty, String plaintext, long id)
 	{
-		this(user, title, description, category, difficulty, plaintext);
-		this.setID(id);
+		this(user, title, description, category, difficulty, plaintext, id, new RealRandomNumberGenerator());
 	}
+	
 
 	public String getCiphertext()
 	{
@@ -153,7 +172,7 @@ public class Cryptogram extends Puzzle
 			posn = posn - 1;
 			// we use posn - 1 so that way there is no chance of the random
 			// element being posn and the element swapping places with itself
-			newPosn = (int) (Math.random() * (posn - 1));
+			newPosn = randomNumberGenerator.random(posn - 1);
 
 			// regular old swapskie
 			temp = alphabet[posn];

--- a/src/pg13/models/IRandomNumberGenerator.java
+++ b/src/pg13/models/IRandomNumberGenerator.java
@@ -1,0 +1,6 @@
+package pg13.models;
+
+public interface IRandomNumberGenerator 
+{
+	public int random(int max);
+}

--- a/src/pg13/models/RealRandomNumberGenerator.java
+++ b/src/pg13/models/RealRandomNumberGenerator.java
@@ -1,0 +1,16 @@
+package pg13.models;
+
+public class RealRandomNumberGenerator implements IRandomNumberGenerator
+{
+	public RealRandomNumberGenerator()
+	{
+		
+	}
+	
+	@Override
+	public int random(int max) 
+	{
+		return (int) (Math.random() * (max));
+	}
+
+}


### PR DESCRIPTION
I had time this morning, so I threw this together as a response to the comment we got on randomness in our testing from the marker.

Added capability to inject stub random number generators to the cryptogram class, and added thoroughness to the tests by using two stub generators: one which generates a left shift cipher, and one which generates a right shift cipher.
